### PR TITLE
fix: fix startup of application

### DIFF
--- a/src/main/kotlin/com/example/plugins/HTTP.kt
+++ b/src/main/kotlin/com/example/plugins/HTTP.kt
@@ -24,11 +24,11 @@ private fun Application.configureCORS(allowedCORSHosts: Set<String>) {
         method(HttpMethod.Delete)
         method(HttpMethod.Patch)
         header(HttpHeaders.Authorization)
-        allowCredentials = true
 
         if (allowedCORSHosts.isEmpty()) {
             anyHost()
         } else {
+            allowCredentials = true
             hosts.addAll(allowedCORSHosts)
         }
     }


### PR DESCRIPTION
allowCredentials is not allowed if using anyHost() anymore, so only apply it if a list of hosts was given.

Signed-off-by: Pascal Nitsche <saikootau@gmail.com>