### PR TITLE
rrfactor(shop): make the ProductRepository use coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     application
@@ -31,6 +32,8 @@ dependencies {
     }
     implementation("ch.qos.logback:logback-classic:1.2.10")
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.0.1")
+
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0")
 
     testImplementation("io.ktor:ktor-server-tests:1.6.7")
 
@@ -90,4 +93,10 @@ dependencyCheck {
     suppressionFile = ".owaspignore.xml"
     cveValidForHours = 24
     failBuildOnCVSS = 7f // Medium and up
+}
+
+tasks.withType<KotlinCompile>().all {
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    }
 }

--- a/src/main/kotlin/com/example/plugins/HTTP.kt
+++ b/src/main/kotlin/com/example/plugins/HTTP.kt
@@ -24,11 +24,11 @@ private fun Application.configureCORS(allowedCORSHosts: Set<String>) {
         method(HttpMethod.Delete)
         method(HttpMethod.Patch)
         header(HttpHeaders.Authorization)
-        allowCredentials = true
 
         if (allowedCORSHosts.isEmpty()) {
             anyHost()
         } else {
+            allowCredentials = true
             hosts.addAll(allowedCORSHosts)
         }
     }

--- a/src/main/kotlin/com/example/shop/Product.kt
+++ b/src/main/kotlin/com/example/shop/Product.kt
@@ -11,16 +11,16 @@ class ProductRepository {
 
     private val products = mutableListOf<Product>()
 
-    fun add(product: Product) {
+    suspend fun add(product: Product) {
         if (null != find(product.id)) {
             throw ProductAlreadyExistsException(product)
         }
 
         products.add(product)
     }
-    fun find(id: UUID) = products.firstOrNull { id == it.id }?.copy()
-    fun findAll() = products.toList()
-    fun remove(id: UUID) {
+    suspend fun find(id: UUID) = products.firstOrNull { id == it.id }?.copy()
+    suspend fun findAll() = products.toList()
+    suspend fun remove(id: UUID) {
         find(id)?.let {
             products.remove(it)
         }

--- a/src/test/kotlin/com/example/shop/ProductRepositoryTest.kt
+++ b/src/test/kotlin/com/example/shop/ProductRepositoryTest.kt
@@ -4,6 +4,7 @@ import assertk.assertThat
 import assertk.assertions.*
 import io.github.databob.Databob
 import io.github.databob.Generators
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -12,12 +13,12 @@ internal class ProductRepositoryTest {
     private val databob = Databob(Generators.ofType { databob -> createProduct(databob) })
 
     @Test
-    fun `is initialized empty`() {
+    fun `is initialized empty`() = runTest {
         assertThat(sut.findAll()).isEmpty()
     }
 
     @Test
-    fun `can add product`() {
+    fun `can add product`() = runTest {
         val product = databob.mk<Product>()
         sut.add(product)
 
@@ -27,7 +28,7 @@ internal class ProductRepositoryTest {
     }
 
     @Test
-    fun `cannot add same product twice`() {
+    fun `cannot add same product twice`() = runTest {
         val product = databob.mk<Product>()
         sut.add(product)
 
@@ -37,7 +38,7 @@ internal class ProductRepositoryTest {
     }
 
     @Test
-    fun `can add multiple products`() {
+    fun `can add multiple products`() = runTest {
         val product1 = databob.mk<Product>()
         val product2 = databob.mk<Product>()
         sut.add(product1)
@@ -49,7 +50,7 @@ internal class ProductRepositoryTest {
     }
 
     @Test
-    fun `can remove product`() {
+    fun `can remove product`() = runTest {
         val product = databob.mk<Product>()
         sut.add(product)
 
@@ -61,7 +62,7 @@ internal class ProductRepositoryTest {
     }
 
     @Test
-    fun `can find product by id`() {
+    fun `can find product by id`() = runTest {
         val product = databob.mk<Product>()
         sut.add(product)
 
@@ -71,7 +72,7 @@ internal class ProductRepositoryTest {
     }
 
     @Test
-    fun `can return all products saved`() {
+    fun `can return all products saved`() = runTest {
         val product1 = databob.mk<Product>()
         val product2 = databob.mk<Product>()
         val product3 = databob.mk<Product>()

--- a/src/test/kotlin/com/example/shop/ShopTest.kt
+++ b/src/test/kotlin/com/example/shop/ShopTest.kt
@@ -28,7 +28,7 @@ internal class ShopTest {
         private val productRepository: ProductRepository = mockk()
 
         @Test fun `empty shop returns empty product list`() {
-            every { productRepository.findAll() } returns emptyList()
+            coEvery { productRepository.findAll() } returns emptyList()
 
             withTestApplication({
                 configureShop(productRepository = productRepository)
@@ -48,7 +48,7 @@ internal class ShopTest {
         }
 
         @Test fun `returns not found on unknown product`() {
-            every { productRepository.find(any()) } returns null
+            coEvery { productRepository.find(any()) } returns null
 
             withTestApplication({
                 configureShop(productRepository = productRepository)
@@ -62,7 +62,7 @@ internal class ShopTest {
         }
 
         @Test fun `product can be created`() {
-            every { productRepository.add(any()) } just runs
+            coEvery { productRepository.add(any()) } just runs
 
             withTestApplication({
                 configureShop(productRepository = productRepository)
@@ -88,7 +88,7 @@ internal class ShopTest {
                         assertThat(price.currencyCode).isEqualTo("EUR")
                     }
 
-                    verify(exactly = 1) { productRepository.add(any()) }
+                    coVerify(exactly = 1) { productRepository.add(any()) }
                 }
             }
         }
@@ -102,7 +102,7 @@ internal class ShopTest {
                     currencyCode = "EUR"
                 )
             )
-            every { productRepository.find(testProduct.id) } returns testProduct
+            coEvery { productRepository.find(testProduct.id) } returns testProduct
 
             withTestApplication({
                 configureShop(productRepository = productRepository)
@@ -122,7 +122,7 @@ internal class ShopTest {
         @Test fun `product can be removed`() {
             val testUUID = UUID.randomUUID()
 
-            every { productRepository.remove(testUUID) } just runs
+            coEvery { productRepository.remove(testUUID) } just runs
 
             withTestApplication({
                 configureShop(productRepository = productRepository)
@@ -132,13 +132,13 @@ internal class ShopTest {
                     assertThat(response).hasStatusNoContent()
                     assertThat(response.content).isNullOrEmpty()
 
-                    verify(exactly = 1) { productRepository.remove(testUUID) }
+                    coVerify(exactly = 1) { productRepository.remove(testUUID) }
                 }
             }
         }
 
         @Test fun `product cannot be created twice`() {
-            every { productRepository.add(any()) } throws ProductAlreadyExistsException(databob.mk())
+            coEvery { productRepository.add(any()) } throws ProductAlreadyExistsException(databob.mk())
 
             withTestApplication({
                 configureShop(productRepository = productRepository)
@@ -158,7 +158,7 @@ internal class ShopTest {
                 }.apply {
                     assertThat(response).hasStatusConflict()
 
-                    verify(exactly = 1) { productRepository.add(any()) }
+                    coVerify(exactly = 1) { productRepository.add(any()) }
                 }
             }
         }


### PR DESCRIPTION
suspend functions on ProductRepository so we can, in the future, use it more easily in a concurrent way.

Signed-off-by: Pascal Nitsche <saikootau@gmail.com>