### PR TITLE
chore(ci): run on JVM version 17

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v3.0.0
         with:
           # The Java version to set up. Takes a whole or semver Java version. See examples of supported syntax in README file
-          java-version: '15'
+          java-version: '17'
           # Java distribution. See the list of supported distributions in README file
           distribution: 'adopt'
           # Set this option if you want the action to check for the latest available version that satisfies the version spec

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,11 @@ COPY . /app
 WORKDIR /app
 RUN ./gradlew clean shadowJar -Dversion=${APP_VERSION}
 
-FROM gcr.io/distroless/java:11
+FROM gcr.io/distroless/java17:nonroot
 ARG APP_VERSION
 
 COPY --from=builder /app/build/libs/ktor-playground-${APP_VERSION}-all.jar /app.jar
 
-USER nonroot
 EXPOSE 8080
 
 CMD [ "app.jar" ]


### PR DESCRIPTION
Current LTS release is Java 17 so the CI should run and target it.

Signed-off-by: Pascal Nitsche <saikootau@gmail.com>