### PR TITLE
test: replace Databob with Fabrikate4k

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,10 +40,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:1.6.10")
     testImplementation("io.mockk:mockk:1.12.3")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.25")
-    testImplementation("io.github.daviddenton:databob.kotlin:1.9.0") {
-        exclude("org.funktionale", "funktionale-all") // excluded because dep was jcenter only, spring is not open to public
-    }
-
+    testImplementation("dev.forkhandles:fabrikate4k:2.0.0.0")
 }
 
 tasks {

--- a/src/test/kotlin/com/example/shop/Databob.kt
+++ b/src/test/kotlin/com/example/shop/Databob.kt
@@ -1,6 +1,0 @@
-package com.example.shop
-
-import io.github.databob.Databob
-
-fun createProduct(databob: Databob) = Product(id = databob.mk(), name = databob.mk(), price = createPrice(databob))
-fun createPrice(databob: Databob) = Price(value = databob.mk(), currencyCode = databob.mk())

--- a/src/test/kotlin/com/example/shop/ProductRepositoryTest.kt
+++ b/src/test/kotlin/com/example/shop/ProductRepositoryTest.kt
@@ -2,15 +2,14 @@ package com.example.shop
 
 import assertk.assertThat
 import assertk.assertions.*
-import io.github.databob.Databob
-import io.github.databob.Generators
+import dev.forkhandles.fabrikate.Fabrikate
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 internal class ProductRepositoryTest {
     private val sut = ProductRepository()
-    private val databob = Databob(Generators.ofType { databob -> createProduct(databob) })
+    private val fabrikate = Fabrikate()
 
     @Test
     fun `is initialized empty`() = runTest {
@@ -19,7 +18,7 @@ internal class ProductRepositoryTest {
 
     @Test
     fun `can add product`() = runTest {
-        val product = databob.mk<Product>()
+        val product = fabrikate.random<Product>()
         sut.add(product)
 
         sut.findAll().apply {
@@ -29,7 +28,7 @@ internal class ProductRepositoryTest {
 
     @Test
     fun `cannot add same product twice`() = runTest {
-        val product = databob.mk<Product>()
+        val product = fabrikate.random<Product>()
         sut.add(product)
 
         assertFailsWith<ProductRepository.ProductAlreadyExistsException> {
@@ -39,8 +38,8 @@ internal class ProductRepositoryTest {
 
     @Test
     fun `can add multiple products`() = runTest {
-        val product1 = databob.mk<Product>()
-        val product2 = databob.mk<Product>()
+        val product1 = fabrikate.random<Product>()
+        val product2 = fabrikate.random<Product>()
         sut.add(product1)
         sut.add(product2)
 
@@ -51,7 +50,7 @@ internal class ProductRepositoryTest {
 
     @Test
     fun `can remove product`() = runTest {
-        val product = databob.mk<Product>()
+        val product = fabrikate.random<Product>()
         sut.add(product)
 
         sut.remove(product.id)
@@ -63,7 +62,7 @@ internal class ProductRepositoryTest {
 
     @Test
     fun `can find product by id`() = runTest {
-        val product = databob.mk<Product>()
+        val product = fabrikate.random<Product>()
         sut.add(product)
 
         sut.find(product.id).apply {
@@ -73,10 +72,10 @@ internal class ProductRepositoryTest {
 
     @Test
     fun `can return all products saved`() = runTest {
-        val product1 = databob.mk<Product>()
-        val product2 = databob.mk<Product>()
-        val product3 = databob.mk<Product>()
-        val product4 = databob.mk<Product>()
+        val product1 = fabrikate.random<Product>()
+        val product2 = fabrikate.random<Product>()
+        val product3 = fabrikate.random<Product>()
+        val product4 = fabrikate.random<Product>()
         sut.add(product1)
         sut.add(product2)
         sut.add(product3)

--- a/src/test/kotlin/com/example/shop/ShopTest.kt
+++ b/src/test/kotlin/com/example/shop/ShopTest.kt
@@ -5,8 +5,7 @@ import assertk.assertions.*
 import com.example.*
 import com.example.plugins.*
 import com.example.shop.ProductRepository.ProductAlreadyExistsException
-import io.github.databob.Databob
-import io.github.databob.Generators
+import dev.forkhandles.fabrikate.Fabrikate
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.*
@@ -19,7 +18,7 @@ import kotlin.test.*
 
 internal class ShopTest {
     private val jsonFormat = Json { isLenient = true }
-    private val databob = Databob(Generators.ofType { databob -> createProduct(databob) })
+    private val fabrikate = Fabrikate()
 
     @Before fun setup() = clearAllMocks()
 
@@ -138,7 +137,7 @@ internal class ShopTest {
         }
 
         @Test fun `product cannot be created twice`() {
-            coEvery { productRepository.add(any()) } throws ProductAlreadyExistsException(databob.mk())
+            coEvery { productRepository.add(any()) } throws ProductAlreadyExistsException(fabrikate.random())
 
             withTestApplication({
                 configureShop(productRepository = productRepository)


### PR DESCRIPTION
We need to replace Databob as it is not maintained anymore. The suggested replacement is Fabrikate4k which has nearly
the same API.