### PR TITLE
Force Java LTS as build target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.owasp.dependencycheck.reporting.ReportGenerator.Format
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     application
     kotlin("jvm") version "1.8.21"
     kotlin("plugin.serialization") version "1.8.21"
     id("io.ktor.plugin") version "2.3.0"
-    id("org.jmailen.kotlinter") version "3.14.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
     id("org.owasp.dependencycheck") version "8.2.1"
     id("jacoco")
 }
@@ -19,7 +19,7 @@ application {
 
 ktor {
     fatJar {
-        archiveFileName.set("ktor-playground-${version}.jar")
+        archiveFileName.set("ktor-playground-$version.jar")
     }
 }
 
@@ -71,7 +71,6 @@ tasks {
         }
     }
 
-
     jacocoTestCoverageVerification {
         violationRules {
             rule {
@@ -89,11 +88,14 @@ jacoco {
     toolVersion = "0.8.10"
 }
 
-kotlinter {
-    ignoreFailures = false
-    reporters = arrayOf("checkstyle", "plain")
-    experimentalRules = false
-    disabledRules = arrayOf("no-wildcard-imports")
+ktlint {
+    verbose.set(true)
+    reporters {
+        reporter(ReporterType.CHECKSTYLE)
+        reporter(ReporterType.JSON)
+        reporter(ReporterType.HTML)
+        reporter(ReporterType.PLAIN)
+    }
 }
 
 dependencyCheck {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,12 @@ application {
     mainClass.set("com.example.ApplicationKt")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 ktor {
     fatJar {
         archiveFileName.set("ktor-playground-$version.jar")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
+import org.owasp.dependencycheck.reporting.ReportGenerator.Format
 
 plugins {
     application
     kotlin("jvm") version "1.8.21"
     kotlin("plugin.serialization") version "1.8.21"
     id("io.ktor.plugin") version "2.3.0"
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
+    id("org.jmailen.kotlinter") version "3.14.0"
     id("org.owasp.dependencycheck") version "8.2.1"
     id("jacoco")
 }
@@ -19,7 +19,7 @@ application {
 
 ktor {
     fatJar {
-        archiveFileName.set("ktor-playground-$version.jar")
+        archiveFileName.set("ktor-playground-${version}.jar")
     }
 }
 
@@ -71,6 +71,7 @@ tasks {
         }
     }
 
+
     jacocoTestCoverageVerification {
         violationRules {
             rule {
@@ -88,14 +89,11 @@ jacoco {
     toolVersion = "0.8.10"
 }
 
-ktlint {
-    verbose.set(true)
-    reporters {
-        reporter(ReporterType.CHECKSTYLE)
-        reporter(ReporterType.JSON)
-        reporter(ReporterType.HTML)
-        reporter(ReporterType.PLAIN)
-    }
+kotlinter {
+    ignoreFailures = false
+    reporters = arrayOf("checkstyle", "plain")
+    experimentalRules = false
+    disabledRules = arrayOf("no-wildcard-imports")
 }
 
 dependencyCheck {


### PR DESCRIPTION
 Kotlin 1.8 does not support Java 20 - to avoid further compile issues force the compile target to be latest Java LTS as it is supported. 
Kotlin 1.9 will support Java 20.